### PR TITLE
Rebuild to add CUDA 13.0 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
+# Override aggregate's [12.9, 13.0]: pytorch 2.10 on pkgs/main ships
+# gpu_cuda128 + gpu_cuda130 builds (no gpu_cuda129), so 12.8 must match.
 cuda_compiler_version:
   - 12.8
   - 13.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,3 @@
 cuda_compiler_version:
   - 12.8
   - 13.0
-pytorch:
-  - 2.8
-  - 2.9
-zip_keys:
-  - cuda_compiler_version
-  - pytorch

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,3 @@
 cuda_compiler_version:
   - 12.8
+  - 13.0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,9 @@
 cuda_compiler_version:
   - 12.8
   - 13.0
+pytorch:
+  - 2.8
+  - 2.9
+zip_keys:
+  - cuda_compiler_version
+  - pytorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - libcusolver-dev
     - libcusparse-dev
     - pip
+    - pybind11
     - python
     - pytorch {{ pytorch }}
     - pytorch {{ pytorch }}.*=*cuda*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,8 @@ requirements:
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
     - ninja
-    - pytorch           # [build_platform != target_platform]
-    - pytorch =*=*cuda*  # [build_platform != target_platform]
+    - pytorch >=2.9           # [build_platform != target_platform]
+    - pytorch >=2.9=*cuda*   # [build_platform != target_platform]
   host:
     - cuda-version {{ cuda_compiler_version }}
     - cuda-cudart-dev
@@ -42,8 +42,8 @@ requirements:
     - pip
     - pybind11
     - python
-    - pytorch
-    - pytorch =*=*cuda*
+    - pytorch >=2.9
+    - pytorch >=2.9=*cuda*
     - setuptools
 
 outputs:
@@ -58,12 +58,12 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         - cuda-cudart-dev
         - python
-        - pytorch
-        - pytorch =*=*cuda*
+        - pytorch >=2.9
+        - pytorch >=2.9=*cuda*
       run:
         - einops
         - python
-        - pytorch =*=*cuda*
+        - pytorch >=2.9=*cuda*
 
     files:
       include:
@@ -90,8 +90,8 @@ outputs:
         - cuda-cudart-dev
         - libcublas-dev
         - python
-        - pytorch
-        - pytorch =*=*cuda*
+        - pytorch >=2.9
+        - pytorch >=2.9=*cuda*
       run:
         - python
         - {{ pin_subpackage('flash-attn', exact=True) }}
@@ -118,8 +118,8 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         - cuda-cudart-dev
         - python
-        - pytorch
-        - pytorch =*=*cuda*
+        - pytorch >=2.9
+        - pytorch >=2.9=*cuda*
       run:
         - python
         - {{ pin_subpackage('flash-attn', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ build:
   number: 1
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
   script_env:
-    # Limit MAX_JOBS in order to prevent runners from crashing
-    - MAX_JOBS=4
+    # MAX_JOBS sets nvcc parallelism; tuned with abs.yaml task_timeout
+    - MAX_JOBS=8
     - TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0;10.0;12.0+PTX
   skip: true  # [cuda_compiler_version == "None" or (not linux64) or py==314]
 
@@ -63,7 +63,7 @@ outputs:
       run:
         - einops
         - python
-        - pytorch =*=*cuda*
+        - pytorch {{ pytorch }}.*=*cuda*
 
     files:
       include:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,12 @@ source:
   - path: setup.py
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
   script_env:
     # Limit MAX_JOBS in order to prevent runners from crashing
     - MAX_JOBS=4
-    - TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0;10.0+PTX
+    - TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0;10.0;12.0+PTX
   skip: true  # [cuda_compiler_version == "None" or (not linux64)]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - libcusolver-dev
     - libcusparse-dev
     - pip
-    - pybind11
     - python
     - pytorch
     - pytorch =*=*cuda*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
     # Limit MAX_JOBS in order to prevent runners from crashing
     - MAX_JOBS=4
     - TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0;10.0;12.0+PTX
-  skip: true  # [cuda_compiler_version == "None" or (not linux64)]
+  skip: true  # [cuda_compiler_version == "None" or (not linux64) or py==314]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,8 @@ requirements:
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
     - ninja
-    - pytorch           # [build_platform != target_platform]
-    - pytorch =*=*cuda*  # [build_platform != target_platform]
+    - pytorch {{ pytorch }}           # [build_platform != target_platform]
+    - pytorch {{ pytorch }}.*=*cuda*  # [build_platform != target_platform]
   host:
     - cuda-version {{ cuda_compiler_version }}
     - cuda-cudart-dev
@@ -41,8 +41,8 @@ requirements:
     - libcusparse-dev
     - pip
     - python
-    - pytorch
-    - pytorch =*=*cuda*
+    - pytorch {{ pytorch }}
+    - pytorch {{ pytorch }}.*=*cuda*
     - setuptools
 
 outputs:
@@ -57,8 +57,8 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         - cuda-cudart-dev
         - python
-        - pytorch
-        - pytorch =*=*cuda*
+        - pytorch {{ pytorch }}
+        - pytorch {{ pytorch }}.*=*cuda*
       run:
         - einops
         - python
@@ -89,8 +89,8 @@ outputs:
         - cuda-cudart-dev
         - libcublas-dev
         - python
-        - pytorch
-        - pytorch =*=*cuda*
+        - pytorch {{ pytorch }}
+        - pytorch {{ pytorch }}.*=*cuda*
       run:
         - python
         - {{ pin_subpackage('flash-attn', exact=True) }}
@@ -117,8 +117,8 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         - cuda-cudart-dev
         - python
-        - pytorch
-        - pytorch =*=*cuda*
+        - pytorch {{ pytorch }}
+        - pytorch {{ pytorch }}.*=*cuda*
       run:
         - python
         - {{ pin_subpackage('flash-attn', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,8 @@ requirements:
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
     - ninja
-    - pytorch >=2.9           # [build_platform != target_platform]
-    - pytorch >=2.9=*cuda*   # [build_platform != target_platform]
+    - pytorch           # [build_platform != target_platform]
+    - pytorch =*=*cuda*  # [build_platform != target_platform]
   host:
     - cuda-version {{ cuda_compiler_version }}
     - cuda-cudart-dev
@@ -42,8 +42,8 @@ requirements:
     - pip
     - pybind11
     - python
-    - pytorch >=2.9
-    - pytorch >=2.9=*cuda*
+    - pytorch
+    - pytorch =*=*cuda*
     - setuptools
 
 outputs:
@@ -58,12 +58,12 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         - cuda-cudart-dev
         - python
-        - pytorch >=2.9
-        - pytorch >=2.9=*cuda*
+        - pytorch
+        - pytorch =*=*cuda*
       run:
         - einops
         - python
-        - pytorch >=2.9=*cuda*
+        - pytorch =*=*cuda*
 
     files:
       include:
@@ -90,8 +90,8 @@ outputs:
         - cuda-cudart-dev
         - libcublas-dev
         - python
-        - pytorch >=2.9
-        - pytorch >=2.9=*cuda*
+        - pytorch
+        - pytorch =*=*cuda*
       run:
         - python
         - {{ pin_subpackage('flash-attn', exact=True) }}
@@ -118,8 +118,8 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
         - cuda-cudart-dev
         - python
-        - pytorch >=2.9
-        - pytorch >=2.9=*cuda*
+        - pytorch
+        - pytorch =*=*cuda*
       run:
         - python
         - {{ pin_subpackage('flash-attn', exact=True) }}


### PR DESCRIPTION
flash-attn 2.8.3 rebuild to add CUDA 13.0 + sm_120 (Blackwell B200).

**Destination channel:** defaults

### Links

- [PKG-11398](https://anaconda.atlassian.net/browse/PKG-11398)
- [Upstream repository](https://github.com/Dao-AILab/flash-attention)

### Explanation of changes

- **Rebuild** of flash-attn 2.8.3 (build number 0 → 1).
- **Local CBC `cuda_compiler_version: [12.8, 13.0]`** overrides aggregate's `[12.9, 13.0]` — pytorch 2.10 on pkgs/main ships `gpu_cuda128` + `gpu_cuda130` builds (no `gpu_cuda129`), so we must align with 12.8.
- **`TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0;10.0;12.0+PTX`** — adds sm_120 (Blackwell B200). CTK 13.0 is required for sm_120 compilation.
- **Skip py3.14** — no pytorch 2.10 py3.14 build on pkgs/main yet.


[PKG-11398]: https://anaconda.atlassian.net/browse/PKG-11398