### PR TITLE
rebuild against pytorch 2.12 (CUDA 12.9 + 13.0); add __cuda run dep

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,0 @@
-# Override aggregate's [12.9, 13.0]: pytorch 2.10 on pkgs/main ships
-# gpu_cuda128 + gpu_cuda130 builds (no gpu_cuda129), so 12.8 must match.
-cuda_compiler_version:
-  - 12.8
-  - 13.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,6 @@ requirements:
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
     - ninja
-    - pytorch {{ pytorch }}           # [build_platform != target_platform]
-    - pytorch {{ pytorch }}.*=*cuda*  # [build_platform != target_platform]
   host:
     - cuda-version {{ cuda_compiler_version }}
     - cuda-cudart-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,13 +15,13 @@ source:
   - path: setup.py
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
   script_env:
     # MAX_JOBS sets nvcc parallelism; tuned with abs.yaml task_timeout
     - MAX_JOBS=8
     - TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0;10.0;12.0+PTX
-  skip: true  # [cuda_compiler_version == "None" or (not linux64) or py==314]
+  skip: true  # [cuda_compiler_version == "None" or (not linux64)]
 
 requirements:
   build:
@@ -61,6 +61,7 @@ outputs:
         - pytorch {{ pytorch }}
         - pytorch {{ pytorch }}.*=*cuda*
       run:
+        - __cuda
         - einops
         - python
         - pytorch {{ pytorch }}.*=*cuda*


### PR DESCRIPTION
flash-attn - rebuild against pytorch 2.12 (CUDA 12.9 + 13.0); add __cuda run dep

**Destination channel:** defaults

### Links

- [PKG-14843](https://anaconda.atlassian.net/browse/PKG-14843) — pytorch 2.12 ABI rebuild
- [PKG-14684](https://anaconda.atlassian.net/browse/PKG-14684) — CUDA 12.9 + 13.0 matrix, `__cuda` run dep
- [Upstream repository](https://github.com/Dao-AILab/flash-attention)
- [Upstream v2.8.3 tag](https://github.com/Dao-AILab/flash-attention/releases/tag/v2.8.3)
- Relevant dependency PRs:
  - [pytorch-feedstock#97](https://github.com/AnacondaRecipes/pytorch-feedstock/pull/97) (pytorch 2.12.0, released to pkgs/main)

### Explanation of changes:

This PR combines two refined sibling tickets that share the same diff surface (CBC + recipe touch). Keeping them as one rebuild avoids a redundant 6+ hour CUDA build cycle.

- **Delete `recipe/conda_build_config.yaml`** — the local override `[12.8, 13.0]` only existed because pytorch 2.10 shipped `gpu_cuda128` + `gpu_cuda130` (no cuda129). pytorch 2.12 ships `gpu_cuda129` + `gpu_cuda130`, which is exactly what aggregate's `[12.9, 13.0]` provides → the override is unnecessary, deleting it inherits aggregate cleanly.
- **`recipe/meta.yaml`:**
  - Build number `1` → `2` so new artifacts supersede existing `py3xx_1` builds on pkgs/main in solver tiebreak; the new `cuda129` build string has no name collision with any existing artifact.
  - Drop `py==314` from the skip selector — pytorch 2.12 ships `gpu_cuda129_py314*` and `gpu_cuda130_py314*` on pkgs/main, so flash-attn for py3.14 is now buildable. Variant matrix will now cover py3.10–3.14.
  - Add `__cuda` to the `flash-attn` output's `run` (PKG-14684). The two child outputs (`flash-attn-fused-dense`, `flash-attn-layer-norm`) `pin_subpackage('flash-attn', exact=True)`, so they inherit `__cuda` transitively — no need to repeat the dep.
- **No `pytorch` pin change in meta.yaml** — the recipe uses the unversioned `{{ pytorch }}` jinja variable, which inherits aggregate's current value `2.12`. The ABI rebuild happens automatically once the artifacts get a fresh build identity (new build number + new `cuda129` string).
- No source / patches changes; upstream flash-attn version stays 2.8.3.

Final variant matrix (linux-64 only, GPU-only): py3.10–3.14 × {CUDA 12.9, CUDA 13.0} = 10 build jobs.

[PKG-14843]: https://anaconda.atlassian.net/browse/PKG-14843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14684]: https://anaconda.atlassian.net/browse/PKG-14684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ