### PR TITLE
rebuild against pytorch 2.13

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+# Override the aggregate CBC's pytorch pin (currently 2.12) so this rebuild
+# links pytorch 2.13 across host/run/test. flash-attn's recipe uses
+# `pytorch {{ pytorch }}`, so this one key repins every occurrence.
+# Remove once the aggregate CBC bumps pytorch to 2.13.
+pytorch:
+  - '2.13'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   - path: setup.py
 
 build:
-  number: 2
+  number: 3
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
   script_env:
     # MAX_JOBS sets nvcc parallelism; tuned with abs.yaml task_timeout


### PR DESCRIPTION
flash-attn - rebuild against pytorch 2.13

**Destination channel:** defaults

### Links
- [PKG-17139](https://anaconda.atlassian.net/browse/PKG-17139) — flash-attn rebuild with pytorch 2.13 (parent: [PKG-12883](https://anaconda.atlassian.net/browse/PKG-12883) Pytorch 2.13)
- [GitHub](https://github.com/Dao-AILab/flash-attention)

### Explanation of changes
- **Rebuild against pytorch 2.13** — the current 2.8.3 build on pkgs/main links pytorch `>=2.12.0,<2.13.0a0` and cannot co-install with pytorch 2.13.
- The recipe pins pytorch via `{{ pytorch }}` (aggregate CBC var, currently `2.12`). Added a local `recipe/conda_build_config.yaml` overriding `pytorch: '2.13'` so every `{{ pytorch }}` occurrence (host / run / test) links 2.13, without waiting for the global CBC bump. The override should be removed once the aggregate CBC advances pytorch to 2.13.
- **build number** 2 → 3 (same upstream version 2.8.3 — rebuild, not a version bump).
- No arch/build-script change: flash-attn's `TORCH_CUDA_ARCH_LIST` (sm_80+) is flash-attn-specific and the CUDA toolkit versions (12.9 / 13.0) are unchanged between pytorch 2.12 and 2.13.

[PKG-17139]: https://anaconda.atlassian.net/browse/PKG-17139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12883]: https://anaconda.atlassian.net/browse/PKG-12883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ